### PR TITLE
feature/memoji-revival

### DIFF
--- a/ENGINEER_BRIEFING.md
+++ b/ENGINEER_BRIEFING.md
@@ -1,0 +1,11 @@
+# Spromoji Engineer Briefing
+
+## Detection Flow
+1. On load, the app attempts quick cartoon detection via `AutoRegions.detectCartoon()` using HSV masks and edge clustering. If successful the regions are used directly.
+2. If that fails, MediaPipe FaceMesh runs (`initializeMediaPipe` creates the detector once). Landmarks are converted with `AutoRegions.fromLandmarks`.
+3. When both methods fail a manual region picker is offered.
+
+## Debug Tips
+- Append `?debug=1` to the WebApp URL to show landmark overlay.
+- Status messages in the page reflect each step of initialization.
+- Use browser console for detailed logs prefixed with `[spromoji]`.

--- a/static/autoRegions.js
+++ b/static/autoRegions.js
@@ -1,37 +1,109 @@
-// converts FaceMesh landmarks to {x,y,w,h} rects with padding
-window.AutoRegions = (function () {
+(function(){
   const PAD = { eye: 1.2, mouth: 1.3 };
 
-  function bbox(points, w, h) {
-    let minX=Infinity,minY=Infinity,maxX=-Infinity,maxY=-Infinity;
-    points.forEach(p=>{ minX=Math.min(minX,p.x); maxX=Math.max(maxX,p.x);
-                        minY=Math.min(minY,p.y); maxY=Math.max(maxY,p.y); });
-    return { x:minX*w, y:minY*h, w:(maxX-minX)*w, h:(maxY-minY)*h };
+  function rgb2hsv(r,g,b){
+    r/=255; g/=255; b/=255;
+    const max=Math.max(r,g,b), min=Math.min(r,g,b);
+    const v=max, d=max-min;
+    const s=max===0?0:d/max;
+    return {s,v};
   }
 
-  const L_EYE_IDXS  = [33,7,163,144,145,153,154,155,133];
-  const R_EYE_IDXS  = [362,382,381,380,374,373,390,249,263];
-  const MOUTH_IDXS  = [61,291,78,308,12,15,13,14];
+  function fromLandmarks(lm,w,h){
+    function bbox(points){
+      let minX=Infinity,minY=Infinity,maxX=-Infinity,maxY=-Infinity;
+      points.forEach(p=>{minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);});
+      return {x:minX*w,y:minY*h,w:(maxX-minX)*w,h:(maxY-minY)*h};
+    }
+    const L=[33,7,163,144,145,153,154,155,133];
+    const R=[362,382,381,380,374,373,390,249,263];
+    const M=[61,291,78,308,12,15,13,14];
+    const left = bbox(L.map(i=>lm[i]));
+    const right= bbox(R.map(i=>lm[i]));
+    const mouth= bbox(M.map(i=>lm[i]));
+    function expand(r,f){const cx=r.x+r.w/2,cy=r.y+r.h/2;return {x:cx-r.w*f/2,y:cy-r.h*f/2,w:r.w*f,h:r.h*f};}
+    return {leftEye:expand(left,PAD.eye),rightEye:expand(right,PAD.eye),mouth:expand(mouth,PAD.mouth)};
+  }
 
-  return function toRegions(lm, cw, ch) {
-    console.debug('[AutoRegions] Processing landmarks:', lm.length, 'canvas:', cw, 'x', ch);
-    
-    const left  = bbox(L_EYE_IDXS.map(i=>lm[i]), cw, ch);
-    const right = bbox(R_EYE_IDXS.map(i=>lm[i]), cw, ch);
-    const mouth = bbox(MOUTH_IDXS.map(i=>lm[i]), cw, ch);
-    
-    console.debug('[AutoRegions] Raw bboxes:', {left, right, mouth});
-    
-    const regions = {
-      leftEye:  expand(left , PAD.eye ),
-      rightEye: expand(right, PAD.eye ),
-      mouth:    expand(mouth, PAD.mouth)
-    };
-    
-    console.debug('[AutoRegions] Final regions:', regions);
-    return regions;
-    
-    function expand(r,f){ const cx=r.x+r.w/2, cy=r.y+r.h/2;
-      return { x:cx-r.w*f/2, y:cy-r.h*f/2, w:r.w*f, h:r.h*f }; }
+  function kmeans(points,k){
+    const centroids=[];
+    for(let i=0;i<k;i++) centroids.push({x:points[Math.floor(points.length*(i+0.5)/k)].x,y:points[Math.floor(points.length*(i+0.5)/k)].y});
+    let changed=true,iter=0;
+    const clusters=new Array(k).fill(0).map(()=>[]);
+    while(changed&&iter<5){
+      clusters.forEach(c=>c.length=0);
+      changed=false;
+      points.forEach(p=>{
+        let best=0,bd=Infinity;
+        for(let i=0;i<k;i++){
+          const dx=p.x-centroids[i].x, dy=(p.y-centroids[i].y)*0.5;
+          const d=dx*dx+dy*dy;
+          if(d<bd){bd=d;best=i;}
+        }
+        clusters[best].push(p);
+      });
+      for(let i=0;i<k;i++){
+        if(clusters[i].length){
+          const cx=clusters[i].reduce((s,p)=>s+p.x,0)/clusters[i].length;
+          const cy=clusters[i].reduce((s,p)=>s+p.y,0)/clusters[i].length;
+          if(cx!==centroids[i].x||cy!==centroids[i].y){centroids[i]={x:cx,y:cy};changed=true;}
+        }
+      }
+      iter++;
+    }
+    return clusters.map((pts,i)=>{
+      let minX=Infinity,minY=Infinity,maxX=0,maxY=0;
+      pts.forEach(p=>{if(p.x<minX)minX=p.x;if(p.x>maxX)maxX=p.x;if(p.y<minY)minY=p.y;if(p.y>maxY)maxY=p.y;});
+      return {x:minX,y:minY,w:maxX-minX,h:maxY-minY,cx:centroids[i].x,cy:centroids[i].y};
+    });
+  }
+
+  function detectCartoon(canvas){
+    const w=canvas.width,h=canvas.height;
+    const ctx=canvas.getContext('2d');
+    const data=ctx.getImageData(0,0,w,h).data;
+    const dark=[];
+    const grad=new Float32Array(w*h);
+    for(let y=1;y<h-1;y++){
+      for(let x=1;x<w-1;x++){
+        const idx=(y*w+x)*4;
+        const r=data[idx],g=data[idx+1],b=data[idx+2];
+        const hsv=rgb2hsv(r,g,b);
+        const gray=(0.299*r+0.587*g+0.114*b)/255;
+        if(!(hsv.s<0.25 && hsv.v>0.85) && gray<0.4) dark.push({x,y});
+        const idxR=idx+4;
+        const idxD=idx+w*4;
+        const gR=(0.299*data[idxR]+0.587*data[idxR+1]+0.114*data[idxR+2])/255;
+        const gD=(0.299*data[idxD]+0.587*data[idxD+1]+0.114*data[idxD+2])/255;
+        grad[y*w+x]=Math.abs(gray-gR)+Math.abs(gray-gD);
+      }
+    }
+    if(dark.length<20) return null;
+    const clusters=kmeans(dark,2).sort((a,b)=>a.cx-b.cx);
+    const pad=5;
+    const left={x:Math.max(clusters[0].x-pad,0),y:Math.max(clusters[0].y-pad,0),w:Math.min(clusters[0].w+pad*2,w),h:Math.min(clusters[0].h+pad*2,h)};
+    const right={x:Math.max(clusters[1].x-pad,0),y:Math.max(clusters[1].y-pad,0),w:Math.min(clusters[1].w+pad*2,w),h:Math.min(clusters[1].h+pad*2,h)};
+    const midY=(clusters[0].cy+clusters[1].cy)/2;
+    let bestY=Math.floor(midY),best=0;
+    for(let y=Math.floor(midY);y<h-1;y++){
+      let sum=0;for(let x=0;x<w;x++) sum+=grad[y*w+x];
+      if(sum>best){best=sum;bestY=y;}
+    }
+    let leftEdge=w,rightEdge=0;
+    for(let x=0;x<w;x++){
+      if(grad[bestY*w+x]>best/w*0.3){
+        if(x<leftEdge) leftEdge=x;
+        if(x>rightEdge) rightEdge=x;
+      }
+    }
+    if(rightEdge-leftEdge<10){leftEdge=w*0.3;rightEdge=w*0.7;}
+    const mh=h*0.2;
+    const mouth={x:Math.max(leftEdge-10,0),y:Math.max(bestY-mh/2,midY),w:Math.min(rightEdge-leftEdge+20,w),h:Math.min(mh,h-(bestY-mh/2))};
+    return {leftEye:left,rightEye:right,mouth:mouth};
+  }
+
+  window.AutoRegions={
+    fromLandmarks,
+    detectCartoon
   };
-})(); 
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -5,7 +5,7 @@
 }
 
 body {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
     color: white;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     min-height: 100vh;
@@ -59,7 +59,7 @@ h1 {
     display: inline-block;
     margin-left: 15px;
     padding: 12px 24px;
-    background: linear-gradient(45deg, #ff9800, #f57c00);
+    background: linear-gradient(45deg, #ffeb3b, #ffc107);
     border: none;
     color: white;
     border-radius: 12px;
@@ -70,9 +70,9 @@ h1 {
 }
 
 .manual-mode-btn:hover {
-    background: linear-gradient(45deg, #f57c00, #ef6c00);
+    background: linear-gradient(45deg, #ffc107, #ffb300);
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(255, 152, 0, 0.5);
+    box-shadow: 0 6px 20px rgba(255, 213, 79, 0.5);
 }
 
 .help-text {
@@ -194,7 +194,7 @@ h1 {
 }
 
 .record-btn {
-    background: linear-gradient(45deg, #ff6b6b, #ee5a24);
+    background: linear-gradient(45deg, #ff3b30, #c0392b);
     border: none;
     color: white;
     padding: 15px 30px;
@@ -202,12 +202,12 @@ h1 {
     border-radius: 25px;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(238, 90, 36, 0.4);
+    box-shadow: 0 4px 15px rgba(192, 57, 43, 0.4);
 }
 
 .record-btn:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(238, 90, 36, 0.6);
+    box-shadow: 0 6px 20px rgba(192, 57, 43, 0.6);
 }
 
 .record-btn:disabled {


### PR DESCRIPTION
## Summary
- add cartoon-friendly autoRegions detection
- update style palette with blue background, yellow accents, and red record button
- refine avatar workflow with manual mode logic and improved uploads
- add jitter and yaw animation tweaks
- cache Telegram profile photos properly and provide engineer briefing
- remove binary test images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68640e8ff1ec83249a6a9649b879018f