### PR TITLE
Improve camera tracking fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ python bot.py
 
 When running with polling, the bot will start in the background and the
 Flask server will serve the WebApp on port `5000` by default.
+
+## Recent changes
+
+- MediaPipe face tracking results are now smoothed across frames for a more fluid Memoji-like animation.

--- a/static/faceWorker.js
+++ b/static/faceWorker.js
@@ -1,9 +1,9 @@
 console.log('[faceWorker] booting…');
 
 import { FilesetResolver, FaceLandmarker } from
-  'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/vision_bundle.mjs';
+  'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/vision_bundle.mjs';
 
-const base = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/wasm';
+const base = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/wasm';
 const landmarker = await FaceLandmarker.create(
   await FilesetResolver.forVisionTasks(base, { forceSIMD:false }),  // WebView safe
   { runningMode:'VIDEO', numFaces:1, outputFaceBlendshapes:true }

--- a/static/script.js
+++ b/static/script.js
@@ -142,12 +142,13 @@ async function initializeMediaPipe() {
     try {
         console.log('[spromoji] Loading MediaPipe...');
         
-        const { FaceLandmarker, FilesetResolver } = await import('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/vision_bundle.mjs');
+        const { FaceLandmarker, FilesetResolver } = await import('https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/vision_bundle.mjs');
         
         console.log('[spromoji] MediaPipe loaded, creating instances...');
         
         const filesetResolver = await FilesetResolver.forVisionTasks(
-            "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/wasm"
+            "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/wasm",
+            { forceSIMD: false }
         );
         
         console.log('[spromoji] FilesetResolver created');
@@ -437,16 +438,31 @@ function startFaceTracking() {
         console.log('[spromoji] Cannot start tracking - missing:', {liveMesh: !!liveMesh, animationEnabled});
         return;
     }
-    
+
     console.log('[spromoji] Starting face tracking loop...');
-    
+
+    let gotLandmarks = false;
+    let prevLandmarks = null;
+
     const trackFace = async () => {
         if (cam.readyState === cam.HAVE_ENOUGH_DATA) {
             try {
                 const results = await liveMesh.detectForVideo(cam, performance.now());
-                
+
                 if (results && results.faceLandmarks && results.faceLandmarks.length > 0) {
-                    const landmarks = results.faceLandmarks[0];
+                    let landmarks = results.faceLandmarks[0];
+
+                    if (prevLandmarks) {
+                        landmarks = landmarks.map((pt, idx) => ({
+                            x: pt.x * 0.6 + prevLandmarks[idx].x * 0.4,
+                            y: pt.y * 0.6 + prevLandmarks[idx].y * 0.4,
+                            z: pt.z * 0.6 + prevLandmarks[idx].z * 0.4
+                        }));
+                    }
+
+                    prevLandmarks = landmarks;
+
+                    gotLandmarks = true;
                     
                     const now = performance.now();
                     if (now - lastFrameTime >= 33) {
@@ -480,6 +496,13 @@ function startFaceTracking() {
     };
     
     trackFace();
+
+    setTimeout(() => {
+        if (!gotLandmarks) {
+            console.warn('[spromoji] No landmarks detected after timeout');
+            updateStatus('Face tracking failed. Try again or adjust lighting.');
+        }
+    }, 5000);
 }
 
 function startBasicAnimation() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Spromoji WebApp</title>
     <link rel="stylesheet" href="/static/style.css" />
-    <!-- MediaPipe Face Landmarker (v0.10.0) -->
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/vision_bundle.mjs"></script>
+    <!-- MediaPipe Face Landmarker (v0.10.3) -->
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.3/vision_bundle.mjs"></script>
     <script src="/static/manualRegions.js"></script>
     <script src="/static/autoRegions.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- bump MediaPipe face landmarker to v0.10.3
- force non-SIMD wasm for better webview compatibility
- add timeout when no landmarks are detected
- smooth landmark updates for fluid animation

## Testing
- `python -m py_compile bot.py`
- `node -e "require('fs').readdirSync('static').forEach(f=>{if(f.endsWith('.js')){require('acorn').parse(require('fs').readFileSync('static/'+f,'utf8'),{ecmaVersion:'latest'});}});"` *(fails: Cannot find module 'acorn')*

------
https://chatgpt.com/codex/tasks/task_e_6865b186f2d0832499d1c7b7f3d40dc0