### PR TITLE
Improve facial feature morphing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ Flask server will serve the WebApp on port `5000` by default.
 
 - MediaPipe face tracking results are now smoothed across frames for a more fluid Memoji-like animation.
 - Landmark smoothing uses the `LANDMARK_SMOOTHING` constant in `script.js` so the effect can be tuned.
+- Facial features now morph to the detected eye and mouth shape for a closer match to your real expressions.
+- Pupils and mouth position now follow your movements for natural blinking and talking.

--- a/static/regionAnimator.js
+++ b/static/regionAnimator.js
@@ -1,9 +1,26 @@
 (function () {
   const BLINK_THRESHOLD = 0.17;  // EAR below this → eye closed
   const MOUTH_OPEN_THR  = 0.35;  // openness above this → mouth open (Pepe mouths often small)
+  const SHAPE_SMOOTHING = 0.3;   // smoothing for eye/mouth shape scaling
+  const MOVE_SMOOTHING  = 0.4;   // smoothing for eye/mouth translation
   const DEBUG_MOUTH = false;
 
   let r = null;  // cached regions + images
+
+  const LEFT_EYE_IDX  = [33, 133, 159, 145];
+  const RIGHT_EYE_IDX = [362, 263, 386, 374];
+  const MOUTH_IDX     = [61, 291, 13, 14];
+  const LEFT_IRIS_C   = 468;  // iris center indices from MediaPipe
+  const RIGHT_IRIS_C  = 473;
+
+  let shapeBaseline = null;  // baseline feature sizes from first frame
+  let posBaseline = null;    // baseline feature centers for movement
+  let shapeState = {
+    leX: 1, leY: 1,
+    reX: 1, reY: 1,
+    mX: 1,  mY: 1
+  };
+  let posState = { leX:0, leY:0, reX:0, reY:0, mX:0, mY:0 };
   
   // AI-driven animation state
   let animState = {
@@ -48,6 +65,76 @@
     return v / h;
   }
 
+  function bbox(lm, idxs){
+    let minX=Infinity, minY=Infinity, maxX=-Infinity, maxY=-Infinity;
+    idxs.forEach(i=>{
+      const p = lm[i];
+      if (p.x<minX) minX=p.x;
+      if (p.x>maxX) maxX=p.x;
+      if (p.y<minY) minY=p.y;
+      if (p.y>maxY) maxY=p.y;
+    });
+    return {w:maxX-minX, h:maxY-minY, cx:(minX+maxX)/2, cy:(minY+maxY)/2};
+  }
+
+  function center(lm, idx){
+    return {x: lm[idx].x, y: lm[idx].y};
+  }
+
+  function updateShape(lm){
+    if(!shapeBaseline){
+      shapeBaseline = {
+        le: bbox(lm, LEFT_EYE_IDX),
+        re: bbox(lm, RIGHT_EYE_IDX),
+        mo: bbox(lm, MOUTH_IDX)
+      };
+      posBaseline = {
+        le: center(lm, LEFT_IRIS_C),
+        re: center(lm, RIGHT_IRIS_C),
+        mo: {x: shapeBaseline.mo.cx, y: shapeBaseline.mo.cy}
+      };
+    }
+
+    const clamp = (v,mi,ma)=>Math.min(ma,Math.max(mi,v));
+    const lerp = (a,b,t)=>a*(1-t)+b*t;
+
+    const leBox = bbox(lm, LEFT_EYE_IDX);
+    const reBox = bbox(lm, RIGHT_EYE_IDX);
+    const moBox = bbox(lm, MOUTH_IDX);
+
+    const tLeX = clamp(leBox.w/shapeBaseline.le.w, 0.5, 1.5);
+    const tLeY = clamp(leBox.h/shapeBaseline.le.h, 0.5, 1.5);
+    const tReX = clamp(reBox.w/shapeBaseline.re.w, 0.5, 1.5);
+    const tReY = clamp(reBox.h/shapeBaseline.re.h, 0.5, 1.5);
+    const tMoX = clamp(moBox.w/shapeBaseline.mo.w, 0.8, 1.5);
+    const tMoY = clamp(moBox.h/shapeBaseline.mo.h, 0.8, 1.6);
+
+    shapeState.leX = lerp(shapeState.leX, tLeX, SHAPE_SMOOTHING);
+    shapeState.leY = lerp(shapeState.leY, tLeY, SHAPE_SMOOTHING);
+    shapeState.reX = lerp(shapeState.reX, tReX, SHAPE_SMOOTHING);
+    shapeState.reY = lerp(shapeState.reY, tReY, SHAPE_SMOOTHING);
+    shapeState.mX  = lerp(shapeState.mX,  tMoX, SHAPE_SMOOTHING);
+    shapeState.mY  = lerp(shapeState.mY,  tMoY, SHAPE_SMOOTHING);
+
+    const leC = center(lm, LEFT_IRIS_C);
+    const reC = center(lm, RIGHT_IRIS_C);
+    const moC = {x: moBox.cx, y: moBox.cy};
+
+    const lePX = clamp((leC.x - posBaseline.le.x) / shapeBaseline.le.w * 2, -1, 1);
+    const lePY = clamp((leC.y - posBaseline.le.y) / shapeBaseline.le.h * 2, -1, 1);
+    const rePX = clamp((reC.x - posBaseline.re.x) / shapeBaseline.re.w * 2, -1, 1);
+    const rePY = clamp((reC.y - posBaseline.re.y) / shapeBaseline.re.h * 2, -1, 1);
+    const moPX = clamp((moC.x - posBaseline.mo.x) / shapeBaseline.mo.w, -0.5, 0.5);
+    const moPY = clamp((moC.y - posBaseline.mo.y) / shapeBaseline.mo.h, -0.5, 0.5);
+
+    posState.leX = lerp(posState.leX, lePX, MOVE_SMOOTHING);
+    posState.leY = lerp(posState.leY, lePY, MOVE_SMOOTHING);
+    posState.reX = lerp(posState.reX, rePX, MOVE_SMOOTHING);
+    posState.reY = lerp(posState.reY, rePY, MOVE_SMOOTHING);
+    posState.mX  = lerp(posState.mX,  moPX, MOVE_SMOOTHING);
+    posState.mY  = lerp(posState.mY,  moPY, MOVE_SMOOTHING);
+  }
+
   window.RegionAnimator = {
     /** cache feature bitmaps & rects */
     init(ctx, regions, avatarImg) {
@@ -87,6 +174,10 @@
       animState.eyeScaleRight = 1.0;
       animState.mouthScale = 1.0;
       animState.globalTilt = 0.0;
+      shapeBaseline = null;
+      posBaseline = null;
+      shapeState = { leX:1, leY:1, reX:1, reY:1, mX:1, mY:1 };
+      posState = { leX:0, leY:0, reX:0, reY:0, mX:0, mY:0 };
       r = null;
       console.debug('[RegionAnimator] State reset');
     },
@@ -105,7 +196,9 @@
         earL = computeEAR(landmarks, 159, 145, 33, 133);
         earR = computeEAR(landmarks, 386, 374, 362, 263);
         mouthO = computeMouthOpenness(landmarks);
-        
+
+        updateShape(landmarks);
+
         if (DEBUG_MOUTH) console.debug('mouth ratio', mouthO.toFixed(2));
       }
 
@@ -137,18 +230,19 @@
       ctx.save();
       const le = r.regs.leftEye;
       ctx.translate(le.x + le.w/2, le.y + le.h/2);
-      
+
       if (landmarks) {
         // Real-time mode: use computed values
         ctx.translate(roll * 5, 0);
-        const blinkL = earL < BLINK_THRESHOLD ? 0 : 1;
-        ctx.globalAlpha = blinkL;
+        ctx.translate(posState.leX * le.w * 0.2, posState.leY * le.h * 0.2);
+        const blinkL = Math.min(1, Math.max(0, earL / BLINK_THRESHOLD));
+        ctx.scale(shapeState.leX, shapeState.leY * blinkL);
       } else {
         // AI-driven mode: use stored animation state
         ctx.translate(animState.globalTilt * 5, 0);
         ctx.scale(1, animState.eyeScaleLeft);
       }
-      
+
       ctx.drawImage(r.leftEyeImg, -le.w/2, -le.h/2, le.w, le.h);
       ctx.globalAlpha = 1;
       ctx.restore();
@@ -157,18 +251,19 @@
       ctx.save();
       const re = r.regs.rightEye;
       ctx.translate(re.x + re.w/2, re.y + re.h/2);
-      
+
       if (landmarks) {
         // Real-time mode: use computed values
         ctx.translate(roll * -5, 0);
-        const blinkR = earR < BLINK_THRESHOLD ? 0 : 1;
-        ctx.globalAlpha = blinkR;
+        ctx.translate(posState.reX * re.w * 0.2, posState.reY * re.h * 0.2);
+        const blinkR = Math.min(1, Math.max(0, earR / BLINK_THRESHOLD));
+        ctx.scale(shapeState.reX, shapeState.reY * blinkR);
       } else {
         // AI-driven mode: use stored animation state
         ctx.translate(animState.globalTilt * -5, 0);
         ctx.scale(1, animState.eyeScaleRight);
       }
-      
+
       ctx.drawImage(r.rightEyeImg, -re.w/2, -re.h/2, re.w, re.h);
       ctx.globalAlpha = 1;
       ctx.restore();
@@ -177,21 +272,19 @@
       ctx.save();
       const mo = r.regs.mouth;
       ctx.translate(mo.x + mo.w/2, mo.y + mo.h/2);
-      
+
       if (landmarks) {
-        // Real-time mode: use mouth openness from landmarks
-        const mouthOpen = mouthO > MOUTH_OPEN_THR;
-        if (mouthOpen) {
-          ctx.translate(0, mo.h * 0.15);
-          ctx.scale(1, 1.3);
-        }
+        // Real-time mode: scale by detected mouth shape
+        ctx.translate(posState.mX * mo.w * 0.3, posState.mY * mo.h * 0.3);
+        ctx.translate(0, (shapeState.mY - 1) * mo.h * 0.15);
+        ctx.scale(shapeState.mX, shapeState.mY);
       } else {
         // AI-driven mode: use stored mouth scale
         const mouthOpenF = (animState.mouthScale - 1.0) / 0.3; // 0→1
-        ctx.translate(0, mouthOpenF * mo.h * 0.15);   // drop when open
-        ctx.scale(1, animState.mouthScale);           // scale up
+        ctx.translate(0, mouthOpenF * mo.h * 0.15);
+        ctx.scale(1, animState.mouthScale);
       }
-      
+
       ctx.drawImage(r.mouthImg, -mo.w/2, -mo.h/2, mo.w, mo.h);
       ctx.restore();
     }


### PR DESCRIPTION
## Summary
- morph eye and mouth shape based on detected landmarks
- reset shape state when clearing animation
- document new morphing capability
- add pupil and mouth movement tracking for more natural expressions

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6865c00ec82483249a153f4fe1087497