### PR TITLE
Update RegionAnimator init calls

### DIFF
--- a/static/manualRegions.js
+++ b/static/manualRegions.js
@@ -335,7 +335,7 @@ function completeSelection() {
         };
     }
     
-    RegionAnimator.init(selectionState.ctx, processedRegions, selectionState.avatarImg);
+    RegionAnimator.init(selectionState.ctx, selectionState.avatarImg);
     avatarRegions = processedRegions;
     animationReady = true;
     log('manual regions set');

--- a/static/script.js
+++ b/static/script.js
@@ -235,7 +235,7 @@ async function tryAutoDetection() {
             console.table(avatarRegions);
             
             if (window.RegionAnimator) {
-                window.RegionAnimator.init(ctx, avatarRegions, avatarImg);
+                window.RegionAnimator.init(ctx, avatarImg);
                 console.log('[spromoji] RegionAnimator initialized with cartoon regions');
             } else {
                 console.error('[spromoji] RegionAnimator not available!');
@@ -273,7 +273,7 @@ async function tryAutoDetection() {
                 console.table(avatarRegions);
                 
                 if (window.RegionAnimator) {
-                    window.RegionAnimator.init(ctx, avatarRegions, avatarImg);
+                    window.RegionAnimator.init(ctx, avatarImg);
                     console.log('[spromoji] RegionAnimator initialized with MediaPipe regions');
                 } else {
                     console.error('[spromoji] RegionAnimator not available!');
@@ -329,7 +329,7 @@ async function startManualSelection() {
         console.table(avatarRegions);
         
         if (window.RegionAnimator) {
-            window.RegionAnimator.init(ctx, avatarRegions, avatarImg);
+            window.RegionAnimator.init(ctx, avatarImg);
             console.log('[spromoji] RegionAnimator initialized with manual regions');
         } else {
             console.error('[spromoji] RegionAnimator not available!');


### PR DESCRIPTION
## Summary
- call `RegionAnimator.init` with `(ctx, avatarImg)` after detection
- adjust manual region selection to use new two-argument `init`

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6865e9a965c083249e9f2d1c430eaa8c