### PR TITLE
Fix overlay canvas always visible

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -55,9 +55,15 @@ async function initializeApp() {
     }
     
     startBtn.addEventListener('click', startRecording);
-    
+
     const urlParams = new URLSearchParams(window.location.search);
     const avatarParam = urlParams.get('avatar');
+    const debugMode = urlParams.get('debug') === '1';
+
+    if (!debugMode) {
+        debugCanvas.style.display = 'none';
+        if (debugOverlay) debugOverlay.style.display = 'none';
+    }
     
     if (avatarParam) {
         console.log('[spromoji] Loading avatar from URL:', avatarParam);

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
         
         <div id="stage">
             <canvas id="avatarCanvas"></canvas>
-            <canvas id="debugCanvas"></canvas>
+            <canvas id="debugCanvas" style="display: none;"></canvas>
             <canvas id="debugOverlay" style="display: none;"></canvas>
             <video id="cam" autoplay playsinline muted hidden></video>
             <div id="loading" class="loading-indicator">


### PR DESCRIPTION
## Summary
- hide debug canvas and overlay by default so the avatar isn't obscured
- show them again only when manual mode or debug mode is enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686731359ed08324b975dad34e4a6052