### PR TITLE
Add telemetry endpoint and error banner

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -57,6 +57,18 @@ def rig_endpoint():
     return {"error": "not implemented"}, 501
 
 
+@app.route("/telemetry", methods=["POST"])
+def telemetry_endpoint():
+    """Receive simple FPS telemetry from clients."""
+    try:
+        data = request.get_json(force=True)
+        print("Telemetry:", data)
+        return {"status": "ok"}
+    except Exception as e:
+        print(f"Telemetry error: {e}")
+        return {"error": "bad request"}, 400
+
+
 
 
 @app.route("/webhook", methods=["POST"])

--- a/static/regionAnimator.js
+++ b/static/regionAnimator.js
@@ -212,7 +212,23 @@
         return true;
       } catch (error) {
         console.error('[RegionAnimator] Mesh system failed to initialize:', error);
-        console.log('[RegionAnimator] Falling back to region-based animation...');
+        if(window.rum && window.rum.trackError){
+          window.rum.trackError(error);
+        }
+        const banner = document.getElementById('errorBanner');
+        if(banner){
+          banner.textContent = 'Rig load failed - using fallback';
+          banner.style.display = 'block';
+        }
+        regionMode = true;
+        const w = img.width, h = img.height;
+        regionData = {
+          leftEye: {cx:w*0.3, cy:h*0.35, rx:w*0.1, ry:h*0.1},
+          rightEye:{cx:w*0.7, cy:h*0.35, rx:w*0.1, ry:h*0.1},
+          mouth:   {cx:w*0.5, cy:h*0.7,  rx:w*0.25, ry:h*0.15}
+        };
+        rig = null;
+        render();
         return false;
       }
     },

--- a/static/script.js
+++ b/static/script.js
@@ -742,3 +742,27 @@ if (document.readyState === 'loading') {
 } else {
     initializeApp();
 }
+
+// simple FPS telemetry
+(function(){
+    let t0 = performance.now();
+    let frames = 0;
+    async function postTelem(fps){
+        try {
+            await fetch('/telemetry', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({fps})});
+        } catch(e){
+            console.warn('telemetry error', e);
+        }
+    }
+    function tick(){
+        frames++;
+        const now = performance.now();
+        if (now - t0 > 10000){
+            postTelem(frames/10);
+            t0 = now;
+            frames = 0;
+        }
+        requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -290,6 +290,19 @@ h1 {
     opacity: 0.9;
 }
 
+.error-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: #dc2626;
+    color: white;
+    padding: 8px;
+    font-weight: bold;
+    z-index: 50;
+    text-align: center;
+}
+
 @media (max-width: 768px) {
     body {
         padding: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,8 +46,9 @@
             <button id="startBtn" class="record-btn">🎬 Start Recording</button>
             <p class="help-text">Position your face in view and click to record a 5-second video</p>
         </div>
-        
+
         <div id="status" class="status-text"></div>
+        <div id="errorBanner" class="error-banner" style="display:none"></div>
     </div>
 
     <script src="https://telegram.org/js/telegram-web-app.js"></script>


### PR DESCRIPTION
## Summary
- surface rig loading failures using an error banner
- add fallback ellipse overlay when rig fails
- capture FPS telemetry and post to the server
- expose new `/telemetry` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674a80dc7c832487a4a0cf447a322e