### PR TITLE
Implement SAM+CLIP fallback stub

### DIFF
--- a/spromoji_rig/main.py
+++ b/spromoji_rig/main.py
@@ -16,12 +16,31 @@ import os
 import io
 from pathlib import Path
 from typing import Dict, Optional
+import time
 
 import numpy as np
 from PIL import Image
 
-from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+
+try:
+    import boto3
+except Exception:  # pragma: no cover - optional dependency
+    boto3 = None
+
+try:
+    import torch
+    from segment_anything import sam_model_registry, SamPredictor
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+    sam_model_registry = None
+    SamPredictor = None
+
+try:
+    import clip
+except Exception:  # pragma: no cover - optional dependency
+    clip = None
 
 API_KEY = "change-me"  # override via environment variable in production
 
@@ -33,6 +52,48 @@ _RIG_CACHE: Dict[str, list] = {}
 # directory to store generated rigs
 CACHE_DIR = Path(os.environ.get("SPROMOJI_RIG_CACHE", Path.home() / ".spromoji_rig"))
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+# optional S3 bucket for persistent cache
+S3_BUCKET = os.environ.get("SPROMOJI_RIG_BUCKET")
+S3_CLIENT = None
+if boto3 and S3_BUCKET:
+    try:  # pragma: no cover - remote services not available in tests
+        S3_CLIENT = boto3.client("s3")
+    except Exception:
+        S3_CLIENT = None
+
+DEVICE = "cuda" if torch and torch.cuda.is_available() else "cpu"
+SAM_PREDICTOR = None
+if SamPredictor and sam_model_registry:
+    ckpt = os.environ.get("SAM_VIT_H_CHECKPOINT")
+    if ckpt:
+        try:  # pragma: no cover - heavy model not present in tests
+            sam_model = sam_model_registry["vit_h"](checkpoint=ckpt).to(DEVICE)
+            SAM_PREDICTOR = SamPredictor(sam_model)
+        except Exception:
+            SAM_PREDICTOR = None
+
+CLIP_MODEL = None
+if clip:
+    try:  # pragma: no cover - heavy model not present in tests
+        CLIP_MODEL, _ = clip.load("ViT-B/32", device=DEVICE)
+    except Exception:
+        CLIP_MODEL = None
+
+_RATE_LIMIT = 60  # requests per minute
+_WINDOW = 60.0
+_REQUEST_LOG: Dict[str, list] = {}
+
+
+def _check_rate_limit(client_id: str) -> None:
+    """Very small in-memory rate limiter."""
+    now = time.time()
+    window_start = now - _WINDOW
+    hits = [t for t in _REQUEST_LOG.get(client_id, []) if t > window_start]
+    if len(hits) >= _RATE_LIMIT:
+        raise HTTPException(status_code=429, detail="rate limit exceeded")
+    hits.append(now)
+    _REQUEST_LOG[client_id] = hits
 
 
 def _load_fixtures() -> None:
@@ -186,15 +247,46 @@ def detect_cartoon_features(img: Image) -> Optional[dict]:
     return {"leftEye": left, "rightEye": right, "mouth": mouth}
 
 
+def box_to_poly(box: dict, w: int, h: int) -> list:
+    """Convert a bounding box dict to normalised polygon."""
+    x, y, w_, h_ = box["x"], box["y"], box["w"], box["h"]
+    return [
+        [x / w, y / h],
+        [(x + w_) / w, y / h],
+        [(x + w_) / w, (y + h_) / h],
+        [x / w, (y + h_) / h],
+    ]
+
+
+def sam_clip_fallback(img: Image) -> Optional[list]:
+    """Placeholder SAM+CLIP segmentation fallback."""
+    if not (SAM_PREDICTOR and CLIP_MODEL):
+        return None
+    # The heavy models are not available in the execution environment.
+    # This stub simply reuses the cartoon heuristic when present.
+    features = detect_cartoon_features(img)
+    if not features:
+        return None
+    w, h = img.size
+    return [
+        {"type": "eyeL", "poly": box_to_poly(features["leftEye"], w, h)},
+        {"type": "eyeR", "poly": box_to_poly(features["rightEye"], w, h)},
+        {"type": "mouth", "poly": box_to_poly(features["mouth"], w, h)},
+    ]
+
+
 _load_fixtures()
 
 
 @app.post("/rig")
 async def rig_endpoint(
-    file: UploadFile = File(None),
+    request: Request,
+    file: UploadFile = File(None, max_length=4 * 1024 * 1024),
     image_b64: Optional[str] = Form(None),
     x_api_key: Optional[str] = Header(None),
 ):
+    client_id = f"{request.client.host}:{x_api_key}"
+    _check_rate_limit(client_id)
     if API_KEY and x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="invalid api key")
 
@@ -210,29 +302,29 @@ async def rig_endpoint(
     cache_file = CACHE_DIR / f"{avatar_hash}.json"
     if cache_file.exists():
         rig = json.loads(cache_file.read_text())
+        if S3_CLIENT:
+            key = f"rigs/{avatar_hash}.json"
+            url = S3_CLIENT.generate_presigned_url(
+                "get_object", Params={"Bucket": S3_BUCKET, "Key": key}, ExpiresIn=3600
+            )
+            return RedirectResponse(url, status_code=302)
         return JSONResponse({"rig": rig, "hash": avatar_hash})
 
     rig = _RIG_CACHE.get(avatar_hash)
     if rig is None:
         img = Image.open(io.BytesIO(data))
         features = detect_cartoon_features(img)
+        rig = None
         if features:
             w, h = img.size
-            def box_to_poly(box):
-                x, y, w_, h_ = box["x"], box["y"], box["w"], box["h"]
-                return [
-                    [x / w, y / h],
-                    [(x + w_) / w, y / h],
-                    [(x + w_) / w, (y + h_) / h],
-                    [x / w, (y + h_) / h],
-                ]
-
             rig = [
-                {"type": "eyeL", "poly": box_to_poly(features["leftEye"])},
-                {"type": "eyeR", "poly": box_to_poly(features["rightEye"])},
-                {"type": "mouth", "poly": box_to_poly(features["mouth"])},
+                {"type": "eyeL", "poly": box_to_poly(features["leftEye"], w, h)},
+                {"type": "eyeR", "poly": box_to_poly(features["rightEye"], w, h)},
+                {"type": "mouth", "poly": box_to_poly(features["mouth"], w, h)},
             ]
-        else:
+        if not rig:
+            rig = sam_clip_fallback(img)
+        if not rig:
             rig = [
                 {"type": "eyeL", "poly": [[0.3, 0.35], [0.4, 0.35], [0.4, 0.45], [0.3, 0.45]]},
                 {"type": "eyeR", "poly": [[0.6, 0.35], [0.7, 0.35], [0.7, 0.45], [0.6, 0.45]]},
@@ -240,4 +332,16 @@ async def rig_endpoint(
             ]
 
     cache_file.write_text(json.dumps(rig))
+
+    if S3_CLIENT:
+        key = f"rigs/{avatar_hash}.json"
+        try:  # pragma: no cover - remote services not available in tests
+            S3_CLIENT.put_object(Bucket=S3_BUCKET, Key=key, Body=json.dumps(rig))
+            url = S3_CLIENT.generate_presigned_url(
+                "get_object", Params={"Bucket": S3_BUCKET, "Key": key}, ExpiresIn=3600
+            )
+            return RedirectResponse(url, status_code=302)
+        except Exception:
+            pass
+
     return JSONResponse({"rig": rig, "hash": avatar_hash})

--- a/spromoji_rig/requirements.txt
+++ b/spromoji_rig/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.29.0
 python-multipart==0.0.9        # file uploads
 pillow==10.3.0                 # image utils (already need this)
 numpy==1.26.4                  # cartoon heuristic
+boto3==1.34.96                 # S3 signed URL cache


### PR DESCRIPTION
## Summary
- add boto3 requirement for S3 caching
- integrate SAM + CLIP stubs and optional S3 signed URL cache
- include simple rate limiting and 4 MB file cap

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686754e911e08324a78c3943e840e668