### PR TITLE
Fix rig init to map avatar features

### DIFF
--- a/static/regionAnimator.js
+++ b/static/regionAnimator.js
@@ -194,14 +194,27 @@
         ctx = context;
         avatarImg = img;
         console.log('[RegionAnimator] Initializing mesh system...');
-        if(regions){
-          regionMode = true;
-          regionData = {
-            leftEye: toFeature(regions.leftEye),
-            rightEye: toFeature(regions.rightEye),
-            mouth: toFeature(regions.mouth)
+      if(regions){
+          const custom = rigFromRegions(regions, img);
+          rig = custom;
+          vertices = custom.vertices.map(v=>({
+            id:v.id,
+            u:v.u,
+            v:v.v,
+            baseX:0,
+            baseY:0,
+            x:0,
+            y:0,
+            weights:v.weights||{}
+          }));
+          triangles = custom.triangles;
+          featureMeshes = {
+            L_EYE:{vertices:vertices.slice(0,2)},
+            R_EYE:{vertices:vertices.slice(2,4)},
+            MOUTH:{vertices:vertices.slice(4,7)}
           };
-          rig = null;
+          regionMode = false;
+          updateVertices();
         } else {
           regionMode = false;
           await loadRig(rigUrl);


### PR DESCRIPTION
## Summary
- build a custom rig from detected feature regions instead of using fallback clipping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c8ee631c8832496f636e67001beba